### PR TITLE
docs + web: README rewrite (no emoji), index UI redesign, archive old issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,31 @@
-# 🤖 GitHub AI Agent
+# GitHub AI Agent
 
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/Python-3.10%2B-blue)](https://www.python.org/)
 
-> Repo này ship **2 surface AI agent** chia theo run mode: **local CLI** cho dev cá nhân, **web/API** cho team workflow.
+Repo này ship **hai surface AI agent** chia theo run mode: một **local CLI** cho dev cá nhân và một **web/API** cho team workflow. Hai surface độc lập về code path.
 
-| | Surface | Run mode | Mục đích chính | Docs |
-|---|---|---|---|---|
-| 🖥️ | **Local AI Agent (CLI)** | 100% local, Ollama, read-only | Hỏi-đáp về codebase ngay từ terminal, có citations | [docs/local_agent/](docs/local_agent/) |
-| 🌐 | **GitHub AI Agent (Web)** | FastAPI + Slack + CI/CD | Multi-agent issue / image / PR review qua Web/Slack | [docs/web_agent/README.md](docs/web_agent/README.md) |
+| Surface | Run mode | Mục đích chính | Docs |
+|---|---|---|---|
+| **Local AI Agent (CLI)** | 100% local, Ollama, read-only | Hỏi-đáp về codebase ngay từ terminal, kèm citations | [docs/local_agent/](docs/local_agent/) |
+| **GitHub AI Agent (Web)** | FastAPI + Slack + CI/CD | Multi-agent issue / image / PR review qua Web/Slack | [docs/web_agent/README.md](docs/web_agent/README.md) |
 
-→ Mới đến repo? Hầu hết dev cần **Local AI Agent (CLI)** trước. Đọc tiếp phần dưới. Đang tìm Web/Slack/CI? Sang [docs/web_agent/README.md](docs/web_agent/README.md).
-
-→ Là AI coding agent? Đọc [AGENTS.md](AGENTS.md) cho boundaries + module status.
+Mới đến repo? Hầu hết dev cần **Local AI Agent (CLI)** trước — đọc tiếp phần dưới. Đang tìm Web/Slack/CI? Sang [docs/web_agent/README.md](docs/web_agent/README.md). Là AI coding agent? Đọc [AGENTS.md](AGENTS.md) cho boundaries và module status.
 
 ---
 
-## 🖥️ Local AI Agent (CLI)
+## Local AI Agent (CLI)
 
-Read-only, suggest-only AI agent chạy 100% local. Pipeline:
+Read-only, suggest-only agent chạy hoàn toàn local. Pipeline:
 
-`câu hỏi → retrieval (FAISS) → context builder → local LLM (Ollama) → answer (with citations)`
+```
+câu hỏi -> retrieval (FAISS) -> context builder -> local LLM (Ollama) -> answer (with citations)
+```
 
 ### Quick start
 
 ```bash
-# 1. Cài deps + kích hoạt venv
+# 1. Tạo venv + cài deps
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 
@@ -33,7 +33,7 @@ pip install -r requirements.txt
 ollama pull llama3:8b
 ollama serve
 
-# 3. Build index cho repo này (1 lần / lần code đổi)
+# 3. Build index cho repo (chạy lại mỗi khi code đổi nhiều)
 python -m src.local_agent.cli index .
 
 # 4. Hỏi
@@ -41,29 +41,33 @@ python -m src.local_agent.cli query "What does LocalAgent.query do?"
 python -m src.local_agent.cli query --json "Where is the scheduler?"
 ```
 
+Model mặc định là `llama3:8b`, đổi được qua biến môi trường `LOCAL_AGENT_MODEL` hoặc cờ `--model`.
+
 ### Docs
 
 - [docs/local_agent/CLI.md](docs/local_agent/CLI.md) — usage, flags, troubleshooting
-- [docs/local_agent/INDEXING.md](docs/local_agent/INDEXING.md) — indexing pipeline chi tiết
-- [docs/local_agent/ARCHITECTURE.md](docs/local_agent/ARCHITECTURE.md) — kiến trúc V1 module-by-module
+- [docs/local_agent/INDEXING.md](docs/local_agent/INDEXING.md) — chi tiết indexing pipeline
+- [docs/local_agent/ARCHITECTURE.md](docs/local_agent/ARCHITECTURE.md) — kiến trúc module-by-module
 
 ### Status
 
-- **V1 (P0-01 → P0-10) hoàn thành**: ingestion → indexing → retrieval → context → LLM → CLI + citations.
-- **Test suite**: `pytest tests/local_agent/` — green except one known pre-existing
-  parser failure (`test_method_decorators_captured`). The hermetic E2E smoke test
-  (`test_e2e_smoke.py`) is skipped unless `faiss-cpu` is installed.
-- **Code path**: [src/local_agent/](src/local_agent/) (~3.5K LOC, độc lập với FastAPI surface).
+- **V1 hoàn thành**: ingestion → indexing → retrieval → context → LLM → CLI, kèm citations + Markdown report.
+- **Test suite**: `pytest tests/local_agent/` xanh, trừ một parser failure đã biết từ trước (`test_method_decorators_captured`). E2E smoke test (`test_e2e_smoke.py`) tự skip khi chưa cài `faiss-cpu`.
+- **Code path**: [src/local_agent/](src/local_agent/) — độc lập với web surface.
+- **Roadmap còn lại**: confidence scorer, read-only tools, planner — xem [GitHub Issues](https://github.com/t2m19102001/github-ai-agent/issues) (label `local-agent`).
 
 ---
 
-## 🌐 GitHub AI Agent (Web / Slack / CI)
+## GitHub AI Agent (Web / Slack / CI)
 
-Multi-agent system với FastAPI backend, Slack bot, GitHub Actions integration, Docker deployment, OCR / diagram analysis.
+Multi-agent system với FastAPI backend, Slack bot, GitHub Actions integration, Docker deployment, và phân tích OCR / diagram.
 
-→ Toàn bộ docs gồm Features, API endpoints, Configuration, Deployment, Use cases: **[docs/web_agent/README.md](docs/web_agent/README.md)**.
+Toàn bộ docs (Features, API endpoints, Configuration, Deployment, Use cases): **[docs/web_agent/README.md](docs/web_agent/README.md)**.
+
+LLM layer (`src/llm/`) gồm `OllamaProvider`, `GroqProvider`, `FailoverProvider`; mặc định dùng `mock` cho test/CI không cần network.
 
 Quick smoke:
+
 ```bash
 # FastAPI dev server
 uvicorn src.web.main:app --host 0.0.0.0 --port 8000 --reload
@@ -74,11 +78,11 @@ docker-compose -f docker-compose.dev.yml up --build
 
 ---
 
-## 🤝 Contributing
+## Contributing
 
 ```bash
 # Fork + branch
-git clone https://github.com/your-username/github-ai-agent.git
+git clone https://github.com/t2m19102001/github-ai-agent.git
 cd github-ai-agent && git checkout -b feature/your-feature
 
 # Dev deps
@@ -88,17 +92,17 @@ pip install -r requirements.txt && pip install -e .
 pytest tests/local_agent/    # local agent
 pytest tests/                # everything
 
-# Lint (CI uses E9,F63,F7,F82 strict)
+# Lint (CI strict set)
 flake8 src/ tests/ --select=E9,F63,F7,F82
 ```
 
-PRs welcome. Tests + lint phải xanh trước khi review.
+PRs welcome. Tests và lint phải xanh trước khi review. Roadmap mở nằm ở [GitHub Issues](https://github.com/t2m19102001/github-ai-agent/issues) (label `roadmap`).
 
-## 📄 License
+## License
 
 MIT — see [LICENSE](LICENSE).
 
-## 🙏 Acknowledgments
+## Acknowledgments
 
 - [Ollama](https://ollama.com) — local LLM runtime
 - [sentence-transformers](https://www.sbert.net) — embedding models
@@ -106,7 +110,7 @@ MIT — see [LICENSE](LICENSE).
 - [FastAPI](https://fastapi.tiangolo.com) — web framework (web surface)
 - [Tesseract](https://github.com/tesseract-ocr/tesseract) — OCR (web surface)
 
-## 📞 Support
+## Support
 
-- Issues: [GitHub Issues](https://github.com/minhman20/github-ai-agent/issues)
-- Discussions: [GitHub Discussions](https://github.com/minhman20/github-ai-agent/discussions)
+- Issues: [GitHub Issues](https://github.com/t2m19102001/github-ai-agent/issues)
+- Discussions: [GitHub Discussions](https://github.com/t2m19102001/github-ai-agent/discussions)

--- a/docs/issues-archive.md
+++ b/docs/issues-archive.md
@@ -1,0 +1,130 @@
+# Issues Archive
+
+> Bản lưu trữ các issue gốc (#1–#5) trước khi xóa vĩnh viễn khỏi GitHub.
+> Xuất ngày 2026-06-20. Các issue này thuộc kiến trúc AI Agent giai đoạn đầu,
+> đã được thay thế bằng bộ roadmap 2-surface mới.
+
+---
+
+## #1 — Test Issue: AI Agent Analysis
+
+- **Author:** @t2m19102001
+- **Created:** 2025-11-28
+- **Labels:** (none)
+
+# Test Issue
+
+This is a test issue to demonstrate the GitHub AI Agent capabilities.
+
+## Problem
+The agent should be able to:
+1. Detect and parse issue content
+2. Analyze the issue using an AI model
+3. Generate helpful comments with insights
+
+## Expected Behavior
+The agent should provide a detailed analysis of this issue.
+
+## Additional Context
+This is a test to verify the AI agent is working correctly.
+
+---
+
+## #2 — Thiết kế abstract base cho AI Provider (Groq, HuggingFace, Ollama, ...): Chuẩn hoá tích hợp đa AI backend
+
+- **Author:** @t2m19102001
+- **Created:** 2025-12-23
+- **Labels:** (none)
+
+## Mục tiêu
+- Xây dựng abstract base class `ProviderBase` để gom toàn bộ logic gọi AI (Groq, HuggingFace, Local Ollama, v.v.) qua 1 interface duy nhất.
+- Dễ mở rộng thêm provider về sau (plug-n-play, dễ test), tránh lặp code.
+
+## Công việc
+- [ ] Tạo file `src/agent/ai_provider.py`
+- [ ] Thiết kế abstract base class `ProviderBase` với các method bắt buộc: `get_response(prompt)`, `is_available()`, `name`
+- [ ] Implement GroqProvider, HuggingFaceProvider, OllamaProvider theo interface chung
+- [ ] Các provider đọc config từ `.env` (hoặc truyền runtime param)
+- [ ] Viết unit test tối giản cho các class provider
+- [ ] Cập nhật `main.py`/core workflow để sử dụng ProviderBase interface
+- [ ] Update README/docs giải thích kiến trúc mới, hướng dẫn thêm provider
+
+## Ghi chú
+- Base này là nền tảng để agent có thể hybrid hoặc fallback nhiều AI backend linh hoạt
+- Tất cả provider đều return response dạng string, throw exception nếu error
+- Có thể dùng ABC và typing của Python cho type-safe
+
+---
+
+## #3 — Refactor agent workflow: sử dụng ProviderBase cho luồng xử lý chính (CLI/API/Web)
+
+- **Author:** @t2m19102001
+- **Created:** 2025-12-23
+- **Labels:** (none)
+
+## Mục tiêu
+- Chuẩn hoá workspace: mọi nơi gọi AI đều đi qua interface ProviderBase (tạo bởi task-provider-base-interface)
+- Giảm duplicate code, dễ bảo trì, cho phép mix nhiều provider, dễ test từng backend
+
+## Công việc
+- [ ] Refactor `main.py`, `run_web.py`, `run_fastapi.py` (nếu có) để dùng ProviderBase
+- [ ] Tích hợp chọn provider (Groq, HuggingFace, Ollama,...) động qua config/biến môi trường/CLI option
+- [ ] Đảm bảo mọi exception/timeout đều được log + xử lý rõ ràng
+- [ ] Cho phép agent fallback giữa các provider nếu provider chính fail
+- [ ] Test thử với ít nhất 2 provider (vd: Groq + HuggingFace)
+- [ ] Update tài liệu, mô tả use-case mới, cách config provider
+
+## Ghi chú:
+- Kết nối mạnh hơn giữa core agent logic và AI backend (ProviderBase)
+- Hướng tới plug-n-play và test tự động từng backend AI khác nhau
+
+---
+
+## #4 — Thiết kế cấu trúc plugin cho AI Agent: hỗ trợ workflow mở rộng dễ dàng
+
+- **Author:** @t2m19102001
+- **Created:** 2025-12-23
+- **Labels:** enhancement
+
+## Mục tiêu
+- Cho phép AI Agent mở rộng các workflow mới (plugin pattern): auto test code, auto tạo PR, custom comment, rule trigger theo label, ...
+- Tách biệt code logic từng feature/thành phần → gắn-tráo đổi dễ test/dễ bảo trì
+
+## Công việc
+- [ ] Thiết kế base `AgentPluginBase` trong `src/agent/plugins/`
+- [ ] Ví dụ 2-3 plugin nhỏ: auto_comment_on_issue, auto_create_pr, auto_check_code_quality
+- [ ] Tích hợp registry: cho phép enable/disable plugin qua config/env
+- [ ] Update workflow để gọi plugin tương ứng khi gặp đúng trigger (vd: khi issue có label bug thì bật code quality plugin)
+- [ ] Viết tài liệu hướng dẫn viết plugin mới
+
+## Ghi chú
+- Hệ thống plugin giúp sản phẩm phát triển mở rộng lâu dài, code luôn clean
+- Với mỗi plugin có thể viết test riêng dễ dàng
+- Lấy cảm hứng từ VSCode extension hoặc pytest plugin pattern
+
+---
+
+## #5 — Xây dựng REST API chuẩn (với FastAPI) cho AI Agent
+
+- **Author:** @t2m19102001
+- **Created:** 2025-12-23
+- **Labels:** (none)
+
+## Mục tiêu
+- Phục vụ nhu cầu tích hợp với hệ thống ngoài, có thể trigger từ script/custom app/webhook/postman
+- Dễ dàng test & mở rộng tính năng bên ngoài CLI truyền thống
+
+## Công việc
+- [ ] Tạo service FastAPI trong `run_fastapi.py`/`src/agent/api.py`
+- [ ] Expose: /analyze-issue, /providers, /plugins endpoint (ví dụ)
+- [ ] Swagger UI auto-gen để test API
+- [ ] Allow config qua env/CLI (port, debug)
+- [ ] Bảo mật cơ bản (token/base auth/allowlist IP)
+- [ ] Viết ví dụ request (curl, Postman, ...)
+
+## Ghi chú
+- Đây là bước quan trọng để AI agent scale hơn, dễ UI/web app hóa sau này
+- FastAPI dễ maint/support async, OpenAPI hỗ trợ tốt auto-docs
+
+---
+

--- a/src/web/static/style.css
+++ b/src/web/static/style.css
@@ -1,43 +1,340 @@
-/* GitHub AI Agent - Phase 3 Styles */
+/* GitHub AI Agent — web surface styles (clean, no icons) */
 
-/* Additional styles for static files */
+:root {
+    --bg: #f4f6f8;
+    --surface: #ffffff;
+    --surface-alt: #f8f9fa;
+    --border: #e1e8ed;
+    --text: #1f2933;
+    --text-muted: #6b7785;
+    --primary: #2563eb;
+    --primary-dark: #1d4ed8;
+    --success: #16a34a;
+    --error: #dc2626;
+    --radius: 10px;
+    --radius-sm: 6px;
+    --shadow: 0 1px 3px rgba(15, 23, 42, 0.08), 0 4px 16px rgba(15, 23, 42, 0.06);
+    --space: 1.5rem;
+    --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: var(--font);
+    color: var(--text);
+    background: var(--bg);
+    line-height: 1.6;
+    padding: var(--space);
+}
+
+.container {
+    max-width: 960px;
+    margin: 0 auto;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    overflow: hidden;
+}
+
+/* Header */
+.header {
+    padding: 2rem var(--space);
+    border-bottom: 1px solid var(--border);
+    background: var(--surface);
+}
+
+.header h1 {
+    font-size: 1.75rem;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+}
+
+.header p {
+    margin-top: 0.35rem;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+}
+
+/* Content */
+.main-content {
+    padding: var(--space);
+}
+
+.form-section {
+    background: var(--surface-alt);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: var(--space);
+    margin-bottom: var(--space);
+}
+
+.form-section h2,
+.results-section h3 {
+    font-size: 1.1rem;
+    margin-bottom: 1rem;
+}
+
+.form-group {
+    margin-bottom: 1.1rem;
+}
+
+.form-group label {
+    display: block;
+    font-weight: 600;
+    font-size: 0.9rem;
+    margin-bottom: 0.4rem;
+}
+
+.form-group input,
+.form-group textarea,
+.form-group select {
+    width: 100%;
+    padding: 0.65rem 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    font-size: 0.95rem;
+    font-family: inherit;
+    color: var(--text);
+    background: var(--surface);
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.form-group input:focus,
+.form-group textarea:focus,
+.form-group select:focus {
+    outline: none;
+    border-color: var(--primary);
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.form-group textarea {
+    resize: vertical;
+    min-height: 120px;
+}
+
+.form-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+}
+
+/* Buttons */
+.btn {
+    background: var(--primary);
+    color: #fff;
+    border: none;
+    padding: 0.7rem 1.4rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+}
+
+.btn:hover {
+    background: var(--primary-dark);
+}
+
+.btn:disabled {
+    background: var(--text-muted);
+    cursor: not-allowed;
+}
+
+/* Loading */
+.loading {
+    text-align: center;
+    padding: 2.5rem var(--space);
+    color: var(--text-muted);
+}
+
+.spinner {
+    border: 3px solid var(--border);
+    border-top-color: var(--primary);
+    border-radius: 50%;
+    width: 38px;
+    height: 38px;
+    animation: spin 0.8s linear infinite;
+    margin: 0 auto 1rem;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+/* Results */
+.results-section {
+    margin-top: var(--space);
+}
+
+.summary-section {
+    background: var(--surface-alt);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--primary);
+    border-radius: var(--radius-sm);
+    padding: 1.1rem var(--space);
+    margin-bottom: var(--space);
+}
+
+.summary-section h3 {
+    margin-bottom: 0.4rem;
+}
+
+.result-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--success);
+    border-radius: var(--radius-sm);
+    padding: 1.1rem var(--space);
+    margin-bottom: 1rem;
+}
+
+.result-card.error {
+    border-left-color: var(--error);
+}
+
+.agent-name {
+    font-size: 1rem;
+    font-weight: 700;
+    margin-bottom: 0.6rem;
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+}
+
+.agent-badge {
+    background: var(--surface-alt);
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    padding: 0.15rem 0.6rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.agent-badge.ok { color: var(--success); border-color: var(--success); }
+.agent-badge.fail { color: var(--error); border-color: var(--error); }
+
+.result-content {
+    background: var(--surface-alt);
+    border-radius: var(--radius-sm);
+    padding: 0.85rem;
+    margin-top: 0.5rem;
+    overflow-x: auto;
+}
+
+.result-content pre {
+    font-family: var(--mono);
+    font-size: 0.85rem;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.result-meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 0.85rem;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.processing-time {
+    background: var(--surface-alt);
+    border-radius: var(--radius-sm);
+    padding: 0.15rem 0.5rem;
+    font-weight: 600;
+}
+
+.error-message {
+    background: #fef2f2;
+    border: 1px solid var(--error);
+    color: var(--error);
+    padding: 0.85rem var(--space);
+    border-radius: var(--radius-sm);
+    margin-top: 1rem;
+}
+
+/* Stats */
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+    margin-top: var(--space);
+}
+
+.stat-card {
+    background: var(--surface-alt);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 1.1rem;
+    text-align: center;
+}
+
+.stat-value {
+    font-size: 1.6rem;
+    font-weight: 700;
+}
+
+.stat-label {
+    color: var(--text-muted);
+    margin-top: 0.25rem;
+    font-size: 0.85rem;
+}
+
+/* API docs helpers (used by other templates) */
 .api-docs {
-    background: #f8f9fa;
-    padding: 20px;
-    border-radius: 10px;
-    margin: 20px 0;
+    background: var(--surface-alt);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: var(--space);
+    margin: var(--space) 0;
 }
 
 .endpoint {
-    background: white;
-    border: 1px solid #e1e8ed;
-    border-radius: 8px;
-    padding: 15px;
-    margin-bottom: 15px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 0.85rem;
+    margin-bottom: 0.85rem;
 }
 
 .method {
     display: inline-block;
-    padding: 4px 8px;
-    border-radius: 4px;
+    padding: 0.15rem 0.5rem;
+    border-radius: var(--radius-sm);
     font-weight: 600;
-    font-size: 0.9em;
-    margin-right: 10px;
+    font-size: 0.8rem;
+    margin-right: 0.6rem;
+    font-family: var(--mono);
 }
 
-.get { background: #28a745; color: white; }
-.post { background: #007bff; color: white; }
-.put { background: #ffc107; color: black; }
-.delete { background: #dc3545; color: white; }
+.get { background: var(--success); color: #fff; }
+.post { background: var(--primary); color: #fff; }
+.put { background: #ca8a04; color: #fff; }
+.delete { background: var(--error); color: #fff; }
 
 .status-indicator {
     display: inline-block;
-    width: 12px;
-    height: 12px;
+    width: 10px;
+    height: 10px;
     border-radius: 50%;
-    margin-right: 8px;
+    margin-right: 0.5rem;
 }
 
-.status-healthy { background: #28a745; }
-.status-warning { background: #ffc107; }
-.status-error { background: #dc3545; }
+.status-healthy { background: var(--success); }
+.status-warning { background: #ca8a04; }
+.status-error { background: var(--error); }
+
+/* Responsive */
+@media (max-width: 640px) {
+    body { padding: 0.75rem; }
+    .form-row { grid-template-columns: 1fr; }
+    .stats-grid { grid-template-columns: 1fr 1fr; }
+}

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -4,284 +4,20 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>GitHub AI Agent - Phase 3</title>
-    <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-
-        body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            min-height: 100vh;
-            padding: 20px;
-        }
-
-        .container {
-            max-width: 1200px;
-            margin: 0 auto;
-            background: white;
-            border-radius: 15px;
-            box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
-            overflow: hidden;
-        }
-
-        .header {
-            background: linear-gradient(135deg, #2c3e50 0%, #3498db 100%);
-            color: white;
-            padding: 30px;
-            text-align: center;
-        }
-
-        .header h1 {
-            font-size: 2.5em;
-            margin-bottom: 10px;
-            text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
-        }
-
-        .header p {
-            font-size: 1.2em;
-            opacity: 0.9;
-        }
-
-        .main-content {
-            padding: 40px;
-        }
-
-        .form-section {
-            background: #f8f9fa;
-            border-radius: 10px;
-            padding: 30px;
-            margin-bottom: 30px;
-            border-left: 5px solid #3498db;
-        }
-
-        .form-group {
-            margin-bottom: 20px;
-        }
-
-        .form-group label {
-            display: block;
-            font-weight: 600;
-            color: #2c3e50;
-            margin-bottom: 8px;
-            font-size: 1.1em;
-        }
-
-        .form-group input,
-        .form-group textarea,
-        .form-group select {
-            width: 100%;
-            padding: 12px;
-            border: 2px solid #e1e8ed;
-            border-radius: 8px;
-            font-size: 1em;
-            transition: all 0.3s ease;
-        }
-
-        .form-group input:focus,
-        .form-group textarea:focus,
-        .form-group select:focus {
-            outline: none;
-            border-color: #3498db;
-            box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.1);
-        }
-
-        .form-group textarea {
-            resize: vertical;
-            min-height: 120px;
-        }
-
-        .form-row {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 20px;
-        }
-
-        .btn {
-            background: linear-gradient(135deg, #3498db 0%, #2980b9 100%);
-            color: white;
-            border: none;
-            padding: 15px 30px;
-            font-size: 1.1em;
-            font-weight: 600;
-            border-radius: 8px;
-            cursor: pointer;
-            transition: all 0.3s ease;
-            box-shadow: 0 4px 15px rgba(52, 152, 219, 0.3);
-        }
-
-        .btn:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 6px 20px rgba(52, 152, 219, 0.4);
-        }
-
-        .btn:disabled {
-            background: #95a5a6;
-            cursor: not-allowed;
-            transform: none;
-            box-shadow: none;
-        }
-
-        .loading {
-            text-align: center;
-            padding: 40px;
-        }
-
-        .spinner {
-            border: 4px solid #f3f3f3;
-            border-top: 4px solid #3498db;
-            border-radius: 50%;
-            width: 50px;
-            height: 50px;
-            animation: spin 1s linear infinite;
-            margin: 0 auto 20px;
-        }
-
-        @keyframes spin {
-            0% {
-                transform: rotate(0deg);
-            }
-
-            100% {
-                transform: rotate(360deg);
-            }
-        }
-
-        .results-section {
-            margin-top: 30px;
-        }
-
-        .result-card {
-            background: white;
-            border-radius: 10px;
-            padding: 25px;
-            margin-bottom: 20px;
-            border-left: 5px solid #27ae60;
-            box-shadow: 0 5px 15px rgba(0, 0, 0, 0.08);
-            transition: all 0.3s ease;
-        }
-
-        .result-card:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 8px 25px rgba(0, 0, 0, 0.12);
-        }
-
-        .result-card.error {
-            border-left-color: #e74c3c;
-        }
-
-        .agent-name {
-            font-size: 1.3em;
-            font-weight: 700;
-            color: #2c3e50;
-            margin-bottom: 15px;
-            display: flex;
-            align-items: center;
-        }
-
-        .agent-badge {
-            background: #3498db;
-            color: white;
-            padding: 4px 12px;
-            border-radius: 20px;
-            font-size: 0.8em;
-            margin-left: 10px;
-        }
-
-        .result-content {
-            background: #f8f9fa;
-            padding: 15px;
-            border-radius: 8px;
-            margin-top: 10px;
-        }
-
-        .result-meta {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-top: 15px;
-            font-size: 0.9em;
-            color: #7f8c8d;
-        }
-
-        .processing-time {
-            background: #e8f5e8;
-            padding: 4px 8px;
-            border-radius: 4px;
-            font-weight: 600;
-        }
-
-        .summary-section {
-            background: linear-gradient(135deg, #f39c12 0%, #e67e22 100%);
-            color: white;
-            padding: 25px;
-            border-radius: 10px;
-            margin-bottom: 20px;
-        }
-
-        .error-message {
-            background: #e74c3c;
-            color: white;
-            padding: 15px;
-            border-radius: 8px;
-            margin-top: 20px;
-        }
-
-        .stats-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-            gap: 20px;
-            margin-top: 30px;
-        }
-
-        .stat-card {
-            background: #f8f9fa;
-            padding: 20px;
-            border-radius: 10px;
-            text-align: center;
-            border-top: 3px solid #3498db;
-        }
-
-        .stat-value {
-            font-size: 2em;
-            font-weight: 700;
-            color: #2c3e50;
-        }
-
-        .stat-label {
-            color: #7f8c8d;
-            margin-top: 5px;
-        }
-
-        @media (max-width: 768px) {
-            .form-row {
-                grid-template-columns: 1fr;
-            }
-
-            .stats-grid {
-                grid-template-columns: 1fr;
-            }
-
-            .main-content {
-                padding: 20px;
-            }
-        }
-    </style>
+    <title>GitHub AI Agent</title>
+    <link rel="stylesheet" href="/static/style.css">
 </head>
 
 <body>
     <div class="container">
         <div class="header">
-            <h1>🤖 GitHub AI Agent</h1>
-            <p>Phase 3: Advanced Intelligence - Multi-agent Workflow</p>
+            <h1>GitHub AI Agent</h1>
+            <p>Multi-agent issue analysis</p>
         </div>
 
         <div class="main-content">
             <div class="form-section">
-                <h2>📝 Analyze GitHub Issue</h2>
+                <h2>Analyze GitHub Issue</h2>
                 <form id="issueForm">
                     <div class="form-group">
                         <label for="title">Issue Title *</label>
@@ -317,25 +53,23 @@
                         <input type="text" id="labels" name="labels" placeholder="e.g., bug, urgent, frontend">
                     </div>
 
-                    <button type="submit" class="btn" id="analyzeBtn">
-                        🚀 Analyze Issue
-                    </button>
+                    <button type="submit" class="btn" id="analyzeBtn">Analyze Issue</button>
                 </form>
             </div>
 
             <div id="loadingSection" class="loading" style="display: none;">
                 <div class="spinner"></div>
-                <h3>🤖 Agents are analyzing your issue...</h3>
-                <p>This may take a few seconds as our multi-agent system processes your request.</p>
+                <h3>Agents are analyzing your issue...</h3>
+                <p>This may take a few seconds as the multi-agent system processes your request.</p>
             </div>
 
             <div id="resultsSection" class="results-section" style="display: none;">
                 <div id="summarySection" class="summary-section">
-                    <h3>📊 Analysis Summary</h3>
+                    <h3>Analysis Summary</h3>
                     <p id="summaryText"></p>
                 </div>
 
-                <h3>🤖 Agent Results</h3>
+                <h3>Agent Results</h3>
                 <div id="agentResults"></div>
 
                 <div class="stats-grid">
@@ -366,13 +100,11 @@
         document.getElementById('issueForm').addEventListener('submit', async (e) => {
             e.preventDefault();
 
-            // Show loading
             document.getElementById('loadingSection').style.display = 'block';
             document.getElementById('resultsSection').style.display = 'none';
             document.getElementById('errorSection').style.display = 'none';
             document.getElementById('analyzeBtn').disabled = true;
 
-            // Get form data
             const formData = new FormData(e.target);
             const issue = {
                 title: formData.get('title'),
@@ -384,12 +116,9 @@
             };
 
             try {
-                // Send request to API
                 const response = await fetch('/analyze_issue', {
                     method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                    },
+                    headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(issue)
                 });
 
@@ -403,17 +132,20 @@
             } catch (error) {
                 displayError('Network error: ' + error.message);
             } finally {
-                // Hide loading
                 document.getElementById('loadingSection').style.display = 'none';
                 document.getElementById('analyzeBtn').disabled = false;
             }
         });
 
+        function escapeHtml(value) {
+            const div = document.createElement('div');
+            div.textContent = value == null ? '' : String(value);
+            return div.innerHTML;
+        }
+
         function displayResults(data) {
-            // Display summary
             document.getElementById('summaryText').textContent = data.summary;
 
-            // Display agent results
             const resultsContainer = document.getElementById('agentResults');
             resultsContainer.innerHTML = '';
 
@@ -421,34 +153,36 @@
                 const resultCard = document.createElement('div');
                 resultCard.className = `result-card ${result.success ? '' : 'error'}`;
 
+                const badgeClass = result.success ? 'ok' : 'fail';
+                const badgeText = result.success ? 'Success' : 'Error';
+                const agentName = escapeHtml(result.agent_name);
+
                 resultCard.innerHTML = `
                     <div class="agent-name">
-                        ${result.agent_name}
-                        <span class="agent-badge">${result.success ? '✅ Success' : '❌ Error'}</span>
+                        ${agentName}
+                        <span class="agent-badge ${badgeClass}">${badgeText}</span>
                     </div>
                     <div class="result-content">
-                        <pre>${JSON.stringify(result.result, null, 2)}</pre>
+                        <pre>${escapeHtml(JSON.stringify(result.result, null, 2))}</pre>
                     </div>
                     <div class="result-meta">
                         <span>Processing Time: <span class="processing-time">${result.processing_time.toFixed(3)}s</span></span>
-                        <span>Agent: ${result.agent_name}</span>
+                        <span>Agent: ${agentName}</span>
                     </div>
                 `;
 
                 if (result.error) {
-                    resultCard.innerHTML += `<div class="error-message">Error: ${result.error}</div>`;
+                    resultCard.innerHTML += `<div class="error-message">Error: ${escapeHtml(result.error)}</div>`;
                 }
 
                 resultsContainer.appendChild(resultCard);
             });
 
-            // Update stats
             document.getElementById('totalAgents').textContent = data.results.length;
             document.getElementById('successfulAgents').textContent = data.results.filter(r => r.success).length;
             document.getElementById('totalTime').textContent = data.total_time.toFixed(2) + 's';
             document.getElementById('taskId').textContent = data.task_id.substring(0, 8) + '...';
 
-            // Show results
             document.getElementById('resultsSection').style.display = 'block';
         }
 
@@ -456,14 +190,13 @@
             const errorSection = document.getElementById('errorSection');
             errorSection.innerHTML = `
                 <div class="error-message">
-                    <h3>❌ Error Occurred</h3>
-                    <p>${message}</p>
+                    <h3>Error Occurred</h3>
+                    <p>${escapeHtml(message)}</p>
                 </div>
             `;
             errorSection.style.display = 'block';
         }
 
-        // Add some sample data for testing
         document.addEventListener('DOMContentLoaded', () => {
             document.getElementById('title').value = 'Bug: Authentication fails on mobile devices';
             document.getElementById('body').value = 'Users are reporting that they cannot log in using mobile browsers. The login button appears to be disabled or unresponsive. This issue seems to affect both iOS and Android devices. Desktop browsers work correctly.';


### PR DESCRIPTION
## Tóm tắt

Ba việc gọn, không trộn với feature citation (đã merge ở #20):

1. **README rewrite** — bỏ hết emoji/icon, sửa link Support/Discussions sai (`minhman20` → `t2m19102001`), trỏ roadmap về GitHub Issues.
2. **Web index UI redesign** — tách inline style ra `static/style.css` (design system bằng CSS variables, responsive, **không icon/emoji**); viết lại `index.html`; giữ nguyên form contract + endpoint `/analyze_issue`.
3. **Archive issues #1–#5** — lưu nội dung issue cũ vào `docs/issues-archive.md` trước khi xóa vĩnh viễn khỏi GitHub.

## Liên quan issue

Issue redesign frontend: #26 (label `frontend`). PR này làm trang `index.html`; dashboard/logs/image còn lại để hoàn thiện nốt theo #26.

## Verification

- **Frontend**: không còn emoji/icon (grep Unicode range = sạch); form id + `/analyze_issue` giữ nguyên; JS `node --check` OK; template render qua Jinja2 OK (len 9161).
- **Security**: thêm `escapeHtml()` trước khi nội suy chuỗi vào `innerHTML` (agent_name / result JSON / error) — vá XSS tiềm ẩn của bản cũ.
- **README**: 0 emoji, link repo đúng.

## Lưu ý ngoài scope (cố ý không đụng)

`src/local_agent/guardrails/filters.py`, `retriever.py` (cleanup import), `AGENTS.md`, `docs/web_agent/` vẫn ở working tree — concern riêng.