### PR TITLE
feat(web): Claude Code-style chat UI with real LLM providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,23 @@ LLM layer (`src/llm/`) gồm `OllamaProvider`, `GroqProvider`, `FailoverProvider
 
 Quick smoke:
 
-```bash
-# FastAPI dev server
-uvicorn src.web.main:app --host 0.0.0.0 --port 8000 --reload
+Chạy ổn định trên localhost với defaults an toàn (mock LLM, SQLite — **không cần Postgres/Redis**):
 
-# Hoặc Docker
+```bash
+# 1. (tuỳ chọn) tạo .env localhost từ template
+cp .env.example .env   # mặc định đã có sẵn LLM_PROVIDER=mock, DATABASE_URL=sqlite
+
+# 2. Boot web surface bằng 1 lệnh (có pre-flight check venv + port)
+bash scripts/run_web.sh                       # http://127.0.0.1:8000
+HOST=0.0.0.0 PORT=9000 bash scripts/run_web.sh
+
+# Kiểm tra: http://127.0.0.1:8000/health · API docs: /docs
+```
+
+Hoặc chạy uvicorn / Docker trực tiếp:
+
+```bash
+uvicorn src.web.main:app --host 127.0.0.1 --port 8000 --reload
 docker-compose -f docker-compose.dev.yml up --build
 ```
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,26 @@ uvicorn src.web.main:app --host 127.0.0.1 --port 8000 --reload
 docker-compose -f docker-compose.dev.yml up --build
 ```
 
+### Web UI
+
+| Route | Mô tả |
+|---|---|
+| `/` | **Chat** kiểu Claude Code — streaming qua WebSocket (`/ws/chat`), model selector, mặc định mock (offline) |
+| `/issue` | Form phân tích GitHub issue (trang chủ cũ) |
+| `/dashboard` · `/logs-page` · `/image-page` | Dashboard, logs, phân tích ảnh |
+| `/docs` · `/health` · `/api/models` | API docs (Swagger) · health check · danh sách provider |
+
+**LLM provider cho chat** (`LLM_PROVIDER` trong `.env`, hoặc chọn ở model selector):
+
+| Provider | Cần gì | Ghi chú |
+|---|---|---|
+| `mock` | không | Mặc định an toàn, offline, trả lời giả lập (để demo UI) |
+| `groq` | `GROQ_API_KEY` (free tại [console.groq.com](https://console.groq.com)) | **Câu trả lời AI thật**, nhanh, model `llama-3.3-70b-versatile` |
+| `ollama` | `ollama serve` + model đã pull | AI thật, 100% local |
+| `failover` | (ưu tiên ollama → groq → mock) | Tự fallback khi provider lỗi |
+
+Để chat trả lời thật: đặt `LLM_PROVIDER=groq` + dán `GROQ_API_KEY=gsk_...` vào `.env`, rồi khởi động lại server.
+
 ---
 
 ## Contributing

--- a/scripts/run_web.sh
+++ b/scripts/run_web.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Boot the GitHub AI Agent web surface (FastAPI) on localhost, one command.
+#
+# Uses safe local defaults: mock LLM, SQLite, no Postgres/Redis required.
+# Reads .env if present (created from .env.example); falls back to built-in
+# defaults otherwise.
+#
+# Usage:
+#   bash scripts/run_web.sh                 # 127.0.0.1:8000, reload on
+#   HOST=0.0.0.0 PORT=9000 bash scripts/run_web.sh
+#   RELOAD=0 bash scripts/run_web.sh        # disable auto-reload
+#
+# Exit codes:
+#   0  server exited cleanly
+#   1  prerequisite missing (venv / uvicorn)
+#   2  port already in use
+
+set -euo pipefail
+
+# Resolve repo root from this script's location so it works from anywhere.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-8000}"
+RELOAD="${RELOAD:-1}"
+
+# Prefer the project venv; fall back to whatever python3 is on PATH.
+if [ -x ".venv/bin/python" ]; then
+    PY=".venv/bin/python"
+else
+    echo "warning: .venv not found; using system python3" >&2
+    PY="python3"
+fi
+
+if ! "${PY}" -c "import uvicorn, fastapi" >/dev/null 2>&1; then
+    echo "error: uvicorn/fastapi not installed in ${PY}." >&2
+    echo "       Run: python -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt" >&2
+    exit 1
+fi
+
+# Fail fast on a busy port instead of letting uvicorn die with a stack trace.
+if command -v lsof >/dev/null 2>&1 && lsof -ti:"${PORT}" >/dev/null 2>&1; then
+    echo "error: port ${PORT} is already in use. Stop the other process or set PORT." >&2
+    exit 2
+fi
+
+RELOAD_FLAG=""
+if [ "${RELOAD}" = "1" ]; then
+    RELOAD_FLAG="--reload"
+fi
+
+echo "Starting web surface on http://${HOST}:${PORT}  (docs: /docs, health: /health)"
+exec "${PY}" -m uvicorn src.web.main:app \
+    --host "${HOST}" \
+    --port "${PORT}" \
+    ${RELOAD_FLAG} \
+    --log-level info

--- a/src/agents/base.py
+++ b/src/agents/base.py
@@ -97,6 +97,12 @@ class Agent(BaseAgent if BaseAgent else ABC):
     def __init__(self, name: str, description: str = ""):
         if BaseAgent:
             super().__init__(name=name, llm_provider=None)
+            # BaseAgent stores history on AgentContext, not on the agent, but
+            # this sync wrapper (and CodeChatAgent.think) expects a per-agent
+            # conversation_history list. Initialize it so both inheritance
+            # paths expose the same attributes.
+            self.description = description
+            self.conversation_history: List[Dict[str, str]] = []
         else:
             self.name = name
             self.description = description

--- a/src/llm/provider.py
+++ b/src/llm/provider.py
@@ -67,6 +67,42 @@ class LLMProvider(BaseLLMProvider):
         return {"name": self.name, "status": "active", "config": self.config}
 
 
-def get_llm_provider(provider_name: str = "mock", config: Dict[str, Any] = None) -> LLMProvider:
-    """Get LLM provider instance"""
-    return LLMProvider(provider_name, config)
+def get_llm_provider(provider_name: str = "mock", config: Dict[str, Any] = None):
+    """Get an LLM provider instance.
+
+    Routes a provider name to a concrete implementation:
+      - "mock" (default): offline echo provider, no network.
+      - "groq": real Groq cloud API (needs GROQ_API_KEY in env/.env).
+      - "ollama": real local Ollama (needs `ollama serve` + a pulled model).
+      - "failover": try Ollama first, then Groq, then mock.
+
+    Any unknown name or import/construction failure falls back to mock so the
+    caller never crashes on an unconfigured provider.
+    """
+    name = (provider_name or "mock").lower()
+
+    if name == "mock":
+        return LLMProvider("mock", config)
+
+    try:
+        if name == "groq":
+            from src.llm.groq import GroqProvider
+            return GroqProvider()
+        if name == "ollama":
+            from src.llm.ollama import OllamaProvider
+            return OllamaProvider()
+        if name == "failover":
+            from src.llm.failover import FailoverProvider
+            from src.llm.ollama import OllamaProvider
+            from src.llm.groq import GroqProvider
+            return FailoverProvider([
+                OllamaProvider(),
+                GroqProvider(),
+                LLMProvider("mock", config),
+            ])
+    except Exception as e:
+        logger.warning(f"Provider '{name}' init failed ({e}); using mock")
+        return LLMProvider("mock", config)
+
+    logger.warning(f"Unknown provider '{name}'; using mock")
+    return LLMProvider("mock", config)

--- a/src/local_agent/guardrails/filters.py
+++ b/src/local_agent/guardrails/filters.py
@@ -4,7 +4,7 @@ Filters Module.
 Purpose: Content filtering for safety.
 """
 
-from typing import List, Tuple, Optional
+from typing import Optional, Tuple
 
 
 class ContentFilter:

--- a/src/local_agent/retrieval/retriever.py
+++ b/src/local_agent/retrieval/retriever.py
@@ -28,7 +28,6 @@ from src.local_agent.ingestion.embedder import DEFAULT_MODEL_NAME, Embedder
 
 if TYPE_CHECKING:
     import faiss
-    import numpy as np
 
 
 class RetrievalSource(str, Enum):

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -13,14 +13,18 @@ from typing import List, Dict, Any, Optional
 project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
 
-from fastapi import FastAPI, HTTPException, Request, Depends, UploadFile, File
+from fastapi import (
+    FastAPI, HTTPException, Request, Depends, UploadFile, File, WebSocket
+)
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
 import uvicorn
 import asyncio
+import json
 import tempfile
+import uuid
 
 # Import logging system
 from src.memory.log_manager import get_logs, get_log_stats, log_activity
@@ -36,7 +40,7 @@ from src.memory.memory_manager import MemoryManager
 from src.llm.provider import get_llm_provider
 from src.utils.logger import get_logger
 from src import __version__
-from src.core.config import validate_config
+from src.core.config import validate_config, LLM_PROVIDER
 from src.utils.embeddings import text_to_embedding
 
 logger = get_logger(__name__)
@@ -114,8 +118,113 @@ class WorkflowResponse(BaseModel):
 # Routes
 @app.get("/", response_class=HTMLResponse)
 async def home(request: Request):
-    """Home page with Web UI"""
+    """Home page: Claude Code-style chat interface."""
+    return templates.TemplateResponse("chat.html", {"request": request})
+
+
+@app.get("/issue", response_class=HTMLResponse)
+async def issue_page(request: Request):
+    """Legacy GitHub issue analysis form (previously served at /)."""
     return templates.TemplateResponse("index.html", {"request": request})
+
+
+@app.get("/api/models")
+async def list_models():
+    """Return selectable providers for the model selector.
+
+    The default reflects LLM_PROVIDER from config/.env, so configuring Groq
+    makes the UI use it without any code change.
+    """
+    providers = ["mock", "groq", "ollama", "failover"]
+    default = (LLM_PROVIDER or "mock").lower()
+    if default not in providers:
+        providers.insert(0, default)
+    return {"models": providers, "default": default}
+
+
+def _generate_reply(llm, message: str, session_id: str) -> str:
+    """Produce an assistant reply, preferring the full CodeChatAgent.
+
+    Falls back to a direct provider call if the agent path raises (it relies on
+    RAG/memory internals that can be fragile in some environments), so the chat
+    socket always returns a response.
+    """
+    try:
+        agent = CodeChatAgent(llm_provider=llm)
+        reply = agent.chat(message, session_id=session_id)
+        if reply:
+            return reply if isinstance(reply, str) else str(reply)
+    except Exception as e:
+        logger.warning(f"agent.chat failed ({e}); falling back to direct call")
+
+    try:
+        messages = [
+            {"role": "system", "content": "Bạn là một AI Code Assistant hữu ích."},
+            {"role": "user", "content": message},
+        ]
+        result = llm.call(messages)
+        return result if isinstance(result, str) else str(result)
+    except Exception as e:
+        logger.error(f"direct provider call failed [{session_id[:8]}]: {e}")
+        return f"⚠️ Không tạo được phản hồi: {e}"
+
+
+@app.websocket("/ws/chat")
+async def chat_websocket(ws: WebSocket):
+    """Streaming chat over WebSocket, backed by CodeChatAgent (offline-capable).
+
+    Client sends: {"message": "...", "model": "mock"}
+    Server emits JSON events: session / thinking / start / chunk / end / error.
+    """
+    await ws.accept()
+    session_id = str(uuid.uuid4())
+    await ws.send_text(json.dumps({"type": "session", "session_id": session_id}))
+
+    try:
+        while True:
+            raw = await ws.receive_text()
+            try:
+                payload = json.loads(raw)
+                message = payload.get("message", "")
+                model = payload.get("model") or "mock"
+            except (ValueError, AttributeError):
+                message, model = raw, "mock"
+
+            message = (message or "").strip()
+            if not message:
+                await ws.send_text(json.dumps({
+                    "type": "error",
+                    "content": "Empty message",
+                }))
+                continue
+
+            # Resolve provider; fall back to mock so an unconfigured provider
+            # never breaks the socket.
+            try:
+                llm = get_llm_provider(model)
+            except Exception as e:
+                logger.warning(f"Provider '{model}' unavailable ({e}); using mock")
+                llm = get_llm_provider("mock")
+
+            await ws.send_text(json.dumps({
+                "type": "thinking",
+                "content": "Đang suy nghĩ...",
+            }))
+
+            text = _generate_reply(llm, message, session_id)
+            await ws.send_text(json.dumps({"type": "start"}))
+            chunk_size = 12
+            for i in range(0, len(text), chunk_size):
+                await ws.send_text(json.dumps({
+                    "type": "chunk",
+                    "content": text[i:i + chunk_size],
+                }))
+                await asyncio.sleep(0.01)
+            await ws.send_text(json.dumps({"type": "end"}))
+
+    except Exception as e:
+        # Includes WebSocketDisconnect; log at debug to avoid noise on normal close.
+        logger.info(f"chat websocket closed [{session_id[:8]}]: {e}")
 
 @app.get("/dashboard", response_class=HTMLResponse)
 async def dashboard(request: Request):

--- a/src/web/static/chat.css
+++ b/src/web/static/chat.css
@@ -1,0 +1,184 @@
+/* Claude Code-style chat UI. Scoped to chat.html only (separate from style.css). */
+
+:root {
+    --bg: #1a1a1a;
+    --bg-elev: #242424;
+    --bg-input: #2a2a2a;
+    --border: #383838;
+    --text: #ececec;
+    --text-dim: #9a9a9a;
+    --accent: #d97757;
+    --accent-hover: #c96545;
+    --user-bubble: #2f2f2f;
+    --assistant-bubble: transparent;
+    --code-bg: #0f0f0f;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body { height: 100%; }
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    font-size: 15px;
+    line-height: 1.6;
+}
+
+.app {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    max-width: 860px;
+    margin: 0 auto;
+}
+
+/* Topbar ----------------------------------------------------------------- */
+.topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 18px;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg);
+}
+.brand { display: flex; align-items: center; gap: 9px; font-weight: 600; }
+.brand .dot {
+    width: 10px; height: 10px; border-radius: 50%;
+    background: var(--accent);
+}
+.topbar-right { display: flex; align-items: center; gap: 12px; }
+.model-label { color: var(--text-dim); font-size: 13px; }
+.model-select {
+    background: var(--bg-input);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 7px;
+    padding: 5px 9px;
+    font-size: 13px;
+    cursor: pointer;
+}
+.conn-status {
+    font-size: 12px;
+    color: var(--text-dim);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 2px 9px;
+}
+.conn-status.ok { color: #6dd58c; border-color: #2e5b3a; }
+.nav-link { color: var(--text-dim); font-size: 13px; text-decoration: none; }
+.nav-link:hover { color: var(--text); }
+
+/* Messages --------------------------------------------------------------- */
+.messages {
+    flex: 1;
+    overflow-y: auto;
+    padding: 24px 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+.welcome { text-align: center; margin: auto 0; color: var(--text-dim); }
+.welcome h1 { color: var(--text); font-size: 26px; margin-bottom: 8px; font-weight: 600; }
+
+.msg { display: flex; }
+.msg-user { justify-content: flex-end; }
+.msg-assistant { justify-content: flex-start; }
+
+.bubble {
+    max-width: 92%;
+    padding: 11px 15px;
+    border-radius: 14px;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+}
+.msg-user .bubble {
+    background: var(--user-bubble);
+    border: 1px solid var(--border);
+    border-bottom-right-radius: 4px;
+}
+.msg-assistant .bubble {
+    background: var(--assistant-bubble);
+    padding-left: 0;
+}
+
+.bubble pre {
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 12px 14px;
+    margin: 8px 0;
+    overflow-x: auto;
+    font-family: "SF Mono", Menlo, Monaco, Consolas, monospace;
+    font-size: 13px;
+    line-height: 1.5;
+}
+.bubble pre code { background: none; color: #e6e6e6; }
+
+/* Thinking indicator ----------------------------------------------------- */
+.thinking .bubble {
+    display: flex; align-items: center; gap: 9px;
+    color: var(--text-dim);
+}
+.think-label { font-size: 13px; }
+.think-dots { display: inline-flex; gap: 4px; }
+.think-dots i {
+    width: 6px; height: 6px; border-radius: 50%;
+    background: var(--accent);
+    animation: blink 1.2s infinite ease-in-out;
+}
+.think-dots i:nth-child(2) { animation-delay: 0.2s; }
+.think-dots i:nth-child(3) { animation-delay: 0.4s; }
+@keyframes blink {
+    0%, 80%, 100% { opacity: 0.3; }
+    40% { opacity: 1; }
+}
+
+/* Composer --------------------------------------------------------------- */
+.composer {
+    padding: 12px 18px 18px;
+    border-top: 1px solid var(--border);
+    background: var(--bg);
+}
+.composer-inner {
+    display: flex;
+    align-items: flex-end;
+    gap: 10px;
+    background: var(--bg-input);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 8px 8px 8px 14px;
+}
+.composer-inner:focus-within { border-color: var(--accent); }
+.input {
+    flex: 1;
+    background: transparent;
+    border: none;
+    outline: none;
+    color: var(--text);
+    font-size: 15px;
+    font-family: inherit;
+    resize: none;
+    line-height: 1.5;
+    max-height: 200px;
+}
+.input::placeholder { color: var(--text-dim); }
+.send-btn {
+    background: var(--accent);
+    color: #fff;
+    border: none;
+    border-radius: 10px;
+    padding: 9px 16px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+}
+.send-btn:hover { background: var(--accent-hover); }
+.send-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.composer-hint {
+    text-align: center;
+    color: var(--text-dim);
+    font-size: 11px;
+    margin-top: 8px;
+}

--- a/src/web/templates/chat.html
+++ b/src/web/templates/chat.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="vi">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GitHub AI Agent — Chat</title>
+    <link rel="stylesheet" href="/static/chat.css">
+</head>
+
+<body>
+    <div class="app">
+        <header class="topbar">
+            <div class="brand">
+                <span class="dot"></span>
+                <span class="brand-name">GitHub AI Agent</span>
+            </div>
+            <div class="topbar-right">
+                <label class="model-label" for="modelSelect">Model</label>
+                <select id="modelSelect" class="model-select" title="Chọn model AI">
+                    <option value="mock">mock</option>
+                </select>
+                <span id="status" class="conn-status" title="Trạng thái kết nối">offline</span>
+                <a class="nav-link" href="/issue">Issue tool</a>
+            </div>
+        </header>
+
+        <main id="messages" class="messages">
+            <div class="welcome">
+                <h1>AI Code Assistant</h1>
+                <p>Hỏi về codebase, gỡ lỗi, hoặc nhờ giải thích. Phản hồi stream theo thời gian thực.</p>
+            </div>
+        </main>
+
+        <footer class="composer">
+            <div class="composer-inner">
+                <textarea id="input" class="input" rows="1"
+                    placeholder="Nhập tin nhắn... (Enter để gửi, Shift+Enter xuống dòng)"></textarea>
+                <button id="send" class="send-btn" title="Gửi">Gửi</button>
+            </div>
+            <div class="composer-hint">mock LLM · 100% local · không gọi mạng</div>
+        </footer>
+    </div>
+
+    <script>
+        const messagesEl = document.getElementById('messages');
+        const inputEl = document.getElementById('input');
+        const sendBtn = document.getElementById('send');
+        const statusEl = document.getElementById('status');
+        const modelSelect = document.getElementById('modelSelect');
+
+        let ws = null;
+        let currentAssistantEl = null;   // streaming target
+        let thinkingEl = null;
+
+        function setStatus(text, ok) {
+            statusEl.textContent = text;
+            statusEl.classList.toggle('ok', !!ok);
+        }
+
+        // --- Render helpers ----------------------------------------------------
+        function appendMessage(role, text) {
+            const wrap = document.createElement('div');
+            wrap.className = `msg msg-${role}`;
+            const bubble = document.createElement('div');
+            bubble.className = 'bubble';
+            renderInto(bubble, text);
+            wrap.appendChild(bubble);
+            messagesEl.appendChild(wrap);
+            scrollToBottom();
+            return bubble;
+        }
+
+        // Minimal, safe rendering: split fenced code blocks, escape everything.
+        function renderInto(el, text) {
+            el.innerHTML = '';
+            const parts = String(text).split(/```/);
+            parts.forEach((part, i) => {
+                if (i % 2 === 1) {
+                    const pre = document.createElement('pre');
+                    const code = document.createElement('code');
+                    code.textContent = part.replace(/^\w*\n/, '');
+                    pre.appendChild(code);
+                    el.appendChild(pre);
+                } else if (part.length) {
+                    const span = document.createElement('span');
+                    span.className = 'text';
+                    span.textContent = part;
+                    el.appendChild(span);
+                }
+            });
+        }
+
+        function scrollToBottom() {
+            messagesEl.scrollTop = messagesEl.scrollHeight;
+        }
+
+        function showThinking() {
+            removeThinking();
+            thinkingEl = document.createElement('div');
+            thinkingEl.className = 'msg msg-assistant thinking';
+            thinkingEl.innerHTML =
+                '<div class="bubble"><span class="think-dots"><i></i><i></i><i></i></span>' +
+                '<span class="think-label">Đang suy nghĩ...</span></div>';
+            messagesEl.appendChild(thinkingEl);
+            scrollToBottom();
+        }
+        function removeThinking() {
+            if (thinkingEl) { thinkingEl.remove(); thinkingEl = null; }
+        }
+
+        // --- WebSocket ---------------------------------------------------------
+        function connect() {
+            const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+            ws = new WebSocket(`${proto}://${location.host}/ws/chat`);
+
+            ws.onopen = () => setStatus('connected', true);
+            ws.onclose = () => { setStatus('offline', false); setTimeout(connect, 1500); };
+            ws.onerror = () => setStatus('error', false);
+
+            ws.onmessage = (ev) => {
+                let data;
+                try { data = JSON.parse(ev.data); } catch { return; }
+
+                switch (data.type) {
+                    case 'session':
+                        break;
+                    case 'thinking':
+                        showThinking();
+                        break;
+                    case 'start':
+                        removeThinking();
+                        currentAssistantEl = appendMessage('assistant', '');
+                        currentAssistantEl._raw = '';
+                        break;
+                    case 'chunk':
+                        if (currentAssistantEl) {
+                            currentAssistantEl._raw += data.content;
+                            renderInto(currentAssistantEl, currentAssistantEl._raw);
+                            scrollToBottom();
+                        }
+                        break;
+                    case 'end':
+                        currentAssistantEl = null;
+                        setSending(false);
+                        break;
+                    case 'error':
+                        removeThinking();
+                        appendMessage('assistant', '⚠️ ' + (data.content || 'Lỗi'));
+                        setSending(false);
+                        break;
+                }
+            };
+        }
+
+        function setSending(sending) {
+            sendBtn.disabled = sending;
+            inputEl.disabled = sending;
+            if (!sending) inputEl.focus();
+        }
+
+        function send() {
+            const text = inputEl.value.trim();
+            if (!text || !ws || ws.readyState !== WebSocket.OPEN) return;
+            appendMessage('user', text);
+            ws.send(JSON.stringify({ message: text, model: modelSelect.value }));
+            inputEl.value = '';
+            autoGrow();
+            setSending(true);
+        }
+
+        // --- Input behaviour ---------------------------------------------------
+        function autoGrow() {
+            inputEl.style.height = 'auto';
+            inputEl.style.height = Math.min(inputEl.scrollHeight, 200) + 'px';
+        }
+        inputEl.addEventListener('input', autoGrow);
+        inputEl.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send(); }
+        });
+        sendBtn.addEventListener('click', send);
+
+        // --- Populate model selector from real backend list --------------------
+        async function loadModels() {
+            try {
+                const res = await fetch('/api/models');
+                const data = await res.json();
+                if (Array.isArray(data.models) && data.models.length) {
+                    modelSelect.innerHTML = '';
+                    data.models.forEach(m => {
+                        const opt = document.createElement('option');
+                        opt.value = m; opt.textContent = m;
+                        modelSelect.appendChild(opt);
+                    });
+                    if (data.default) modelSelect.value = data.default;
+                }
+            } catch { /* keep default option */ }
+        }
+
+        loadModels();
+        connect();
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
## Tóm tắt

Thay trang chủ `/` của web surface bằng **giao diện chat kiểu Claude Code** (streaming, model selector, thinking indicator) và wire vào **LLM provider thật** (Groq / Ollama / Failover). Form phân tích issue cũ chuyển sang `/issue`.

PR này gồm 3 commit nối tiếp trong cùng một mạch công việc:

| Commit | Nội dung |
|---|---|
| `26c1a5c` | refactor: bỏ dead imports trong `filters.py`, `retriever.py` |
| `61ac49b` | feat: script chạy localhost 1 lệnh (`scripts/run_web.sh`) + docs |
| `59848bc` | feat: chat UI kiểu Claude Code + provider routing |

## Thay đổi chính

**Chat UI**
- `GET /` → `chat.html` (dark theme, `chat.css` tách riêng khỏi `style.css`).
- WebSocket `/ws/chat`: streaming theo chunk, events `session/thinking/start/chunk/end/error`, có fallback gọi provider trực tiếp để socket luôn trả lời.
- `GET /api/models` + model selector: `mock | groq | ollama | failover`, mặc định đọc từ `LLM_PROVIDER` trong `.env`.
- Render code block an toàn (escape, `<pre>`).

**LLM providers**
- `get_llm_provider()` route sang `GroqProvider` / `OllamaProvider` / `FailoverProvider` (trước đây luôn trả mock). Tên lạ / init lỗi → fallback `mock`, không crash. Đường `"mock"` giữ nguyên (bảo toàn contract `test_basic`).
- Groq dùng `llama-3.3-70b-versatile`; key đọc từ `.env` (**gitignored**, không nằm trong PR).

**Bugfix (pre-existing)**
- `base.py`: nhánh kế thừa `BaseAgent` quên khởi tạo `self.conversation_history` → crash `CodeChatAgent.chat()` trong app thật. Đã sửa.

## Kiểm thử

- flake8 strict (`E9,F63,F7,F82`) + `py_compile`: PASS.
- CI gate (`tests/test_basic.py`, `tests/test_stability_fixes.py`): **11 passed**.
- Baseline-diff toàn suite: **không phát sinh regression mới** (14 failures pre-existing không liên quan).
- WebSocket end-to-end: Groq trả lời thật (chat + code block) verified trực tiếp.

## Ghi chú

- `.env` (chứa `GROQ_API_KEY`) **không** nằm trong PR — gitignored. Người dùng tự đặt key để bật Groq; mặc định `mock` chạy offline không cần gì.
- Runtime artifacts (`data/memory.db`, `logs.db`, `data/vector_store/`) cố ý không commit.